### PR TITLE
Fix #27 (Allow usage of newer six and protobuf)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-protobuf==3.6.0
-six==1.11.0
+protobuf>=3.19.3
+six>=1.16.0
 bsdiff4>=1.1.5


### PR DESCRIPTION
Python 3.10 now requires `collections.abc.Mapping`. `collections.Mapping` was deprecated in Python 3.9, and was removed in 3.10
Newer protobuf library fixes this problem. Older Protobuf versions fail to work on Python 3.9 and older.