### PR TITLE
Pin maximum protobuf version to 3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-protobuf>=3.19.3
+protobuf>=3.19.3, <=3.20.1
 six>=1.16.0
 bsdiff4>=1.1.5


### PR DESCRIPTION
I am getting an error if I don't pin a maximum protobuf version:

```
Traceback (most recent call last):
  File "/home/dan/Projects/payload_dumper/payload_dumper.py", line 15, in <module>
    import update_metadata_pb2 as um
  File "/home/dan/Projects/payload_dumper/update_metadata_pb2.py", line 33, in <module>
    _descriptor.EnumValueDescriptor(
  File "/home/dan/Projects/payload_dumper/.venv/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```