### PR TITLE
Point shebang to correct version of python

### DIFF
--- a/payload_dumper.py
+++ b/payload_dumper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import struct
 import hashlib
 import bz2


### PR DESCRIPTION
Point the shebang of the script to `python3` instead of python.

This seems like a more viable thing to do, since many systems might have both python 2 and python3 installed; in such cases, the `python` command might run python 2 (which is what used to happen on my previous installation of Debian).
In some other cases, where only python3 is installed, `python` may not even be an executable in the first place (which is the case on my current Debian installation; running `python` throws an error "python: no such file or directory"

With the correct shebang, the script can be run directly (as in `payload_dumper.py <payload.bin>`)