### PR TITLE
Prompt to install bsdiff4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Script tested on Yandex Amber OTA's (full and incremental) under Linux(but may w
 
 - Python3, pip
 - google protobuf for python `pip install protobuf`
+- binary diff and patch for python `pip install bsdiff4`
 
 ### Docker
 


### PR DESCRIPTION
The newly added dependency package bsdiff4 needs to be installed with pip.