### PR TITLE
re-enable SHA256 hash checking

### DIFF
--- a/payload_dumper.py
+++ b/payload_dumper.py
@@ -81,7 +81,8 @@ def data_for_op(op,out_file,old_file):
     args.payloadfile.seek(data_offset + op.data_offset)
     data = args.payloadfile.read(op.data_length)
 
-    # assert hashlib.sha256(data).digest() == op.data_sha256_hash, 'operation data hash mismatch'
+    if op.data_sha256_hash:
+        assert hashlib.sha256(data).digest() == op.data_sha256_hash, 'operation data hash mismatch'
 
     if op.type == op.REPLACE_XZ:
         dec = lzma.LZMADecompressor()


### PR DESCRIPTION
The hash field is optional, so only assert a match if it's present. Tested on OnePlus CPH2611 full/incremental OTAs.

If there was a bigger reason this assert was commented out, feel free to ignore/close this PR.  I'm just happy it confirmed that my last contribution is working. 😄 