### PR TITLE
Update the requirements.txt with zstandard version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ protobuf>=5.27.3
 six>=1.16.0
 bsdiff4>=1.1.5
 brotli>=1.1.0
-zstandard
+zstandard>=0.23.0


### PR DESCRIPTION
Specify the zstandard module version to avoid issues in some systems that don't install the zstandard module because of missing version